### PR TITLE
Improve AutoFigure frontend: persist config, sanitize XML, add gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,49 @@
+# Python
+__pycache__
+*.py[cod]
+*$py.class
+*.egg-info/
+*.egg
+dist/
+build/
+*.whl
+*.so
+
+# Virtual environments
+venv/
+.venv/
+env/
+
+# IDE
+.idea/
+.vscode/
+*.swp
+*.swo
+*~
+
+# OS
+.DS_Store
+Thumbs.db
+
+# Logs
+*.log
+/tmp/
+
+# Output
+autofigure_output/
+
+# Environment / secrets
+.env
+.env.*
+
+# Node (frontend has its own .gitignore, but just in case)
+node_modules/
+
+# Testing
+.pytest_cache/
+.coverage
+htmlcov/
+
+# mypy / ruff
+.mypy_cache/
+.ruff_cache/

--- a/frontend/app/autofigure/canvas/page.tsx
+++ b/frontend/app/autofigure/canvas/page.tsx
@@ -8,7 +8,7 @@ import IterationControlsFloating from "@/components/autofigure/IterationControls
 import BeautificationDialog from "@/components/autofigure/BeautificationDialog"
 import EnhancedImageGallery from "@/components/autofigure/EnhancedImageGallery"
 import GenerationOverlay from "@/components/autofigure/GenerationOverlay"
-import { extractDiagramXML } from "@/lib/utils"
+import { extractDiagramXML, sanitizeXmlForDrawio } from "@/lib/utils"
 import type { AutoFigureConfig } from "@/lib/autofigure-types"
 import {
     Sparkles,
@@ -120,8 +120,9 @@ function AutoFigureCanvasContent() {
     // Load XML into draw.io when currentXml changes
     useEffect(() => {
         if (drawioRef.current && currentXml && isDrawioReady) {
-            console.log('[AutoFigure Canvas] Loading XML into DrawIO, length:', currentXml.length)
-            drawioRef.current.load({ xml: currentXml })
+            const cleanXml = sanitizeXmlForDrawio(currentXml)
+            console.log('[AutoFigure Canvas] Loading XML into DrawIO, length:', cleanXml.length)
+            drawioRef.current.load({ xml: cleanXml })
         }
     }, [currentXml, isDrawioReady])
 
@@ -263,7 +264,7 @@ function AutoFigureCanvasContent() {
 
     const loadIteration = (xml: string) => {
         if (drawioRef.current && isDrawioReady) {
-            drawioRef.current.load({ xml })
+            drawioRef.current.load({ xml: sanitizeXmlForDrawio(xml) })
         }
     }
 

--- a/frontend/contexts/autofigure-context.tsx
+++ b/frontend/contexts/autofigure-context.tsx
@@ -1,7 +1,7 @@
 "use client"
 
 import type React from "react"
-import { createContext, useContext, useState, useCallback, useRef } from "react"
+import { createContext, useContext, useState, useCallback, useRef, useEffect } from "react"
 import type {
     AutoFigureConfig,
     AutoFigureSession,
@@ -12,6 +12,27 @@ import type {
 } from "@/lib/autofigure-types"
 import { DEFAULT_CONFIG } from "@/lib/autofigure-types"
 import { wrapWithMxFile } from "@/lib/utils"
+
+const STORAGE_CONFIG_KEY = "autofigure-config"
+
+function loadConfigFromStorage(): AutoFigureConfig {
+    if (typeof window === "undefined") return DEFAULT_CONFIG
+    try {
+        const stored = localStorage.getItem(STORAGE_CONFIG_KEY)
+        if (stored) {
+            return { ...DEFAULT_CONFIG, ...JSON.parse(stored) }
+        }
+    } catch {}
+    return DEFAULT_CONFIG
+}
+
+function saveConfigToStorage(config: AutoFigureConfig) {
+    if (typeof window === "undefined") return
+    try {
+        const { inputText, ...toSave } = config
+        localStorage.setItem(STORAGE_CONFIG_KEY, JSON.stringify(toSave))
+    } catch {}
+}
 
 interface AutoFigureContextType {
     // Configuration
@@ -50,8 +71,8 @@ interface AutoFigureContextType {
 const AutoFigureContext = createContext<AutoFigureContextType | undefined>(undefined)
 
 export function AutoFigureProvider({ children }: { children: React.ReactNode }) {
-    // Configuration state
-    const [config, setConfig] = useState<AutoFigureConfig>(DEFAULT_CONFIG)
+    // Configuration state - load from localStorage
+    const [config, setConfig] = useState<AutoFigureConfig>(loadConfigFromStorage)
 
     // Session state
     const [session, setSession] = useState<AutoFigureSession | null>(null)
@@ -80,11 +101,16 @@ export function AutoFigureProvider({ children }: { children: React.ReactNode }) 
     }
 
     const updateConfig = useCallback((updates: Partial<AutoFigureConfig>) => {
-        setConfig(prev => ({ ...prev, ...updates }))
+        setConfig(prev => {
+            const next = { ...prev, ...updates }
+            saveConfigToStorage(next)
+            return next
+        })
     }, [])
 
     const resetConfig = useCallback(() => {
         setConfig(DEFAULT_CONFIG)
+        saveConfigToStorage(DEFAULT_CONFIG)
     }, [])
 
     const clearError = useCallback(() => {

--- a/frontend/lib/utils.ts
+++ b/frontend/lib/utils.ts
@@ -54,6 +54,21 @@ export function formatXML(xml: string, indent: string = "  "): string {
 }
 
 /**
+ * Sanitize mxGraph XML for draw.io embed API.
+ * Removes <Array> elements and orphaned <mxPoint> elements that cause
+ * "Could not add object Array" errors in the draw.io embed component.
+ * Edge waypoints are removed but edges still connect correctly.
+ */
+export function sanitizeXmlForDrawio(xml: string): string {
+    if (!xml) return xml
+    // Remove <Array ...>...</Array> blocks (including their child mxPoints)
+    let sanitized = xml.replace(/<Array\b[^>]*>[\s\S]*?<\/Array>/g, "")
+    // Remove orphaned <mxPoint> without 'as' attribute
+    sanitized = sanitized.replace(/<mxPoint\b(?![^>]*\sas=)[^>]*\/>/g, "")
+    return sanitized
+}
+
+/**
  * Efficiently converts a potentially incomplete XML string to a legal XML string by closing any open tags properly.
  * Additionally, if an <mxCell> tag does not have an mxGeometry child (e.g. <mxCell id="3">),
  * it removes that tag from the output.


### PR DESCRIPTION
- Persist AutoFigure config to localStorage so API keys survive page refresh
- Sanitize mxGraph XML before loading into draw.io to fix "Could not add object Array" errors
- Add root .gitignore for Python cache, venv, IDE files, etc.