### PR TITLE
fix: gate prompt caching by provider, not model name only

### DIFF
--- a/frontend/app/api/chat/route.ts
+++ b/frontend/app/api/chat/route.ts
@@ -8,7 +8,11 @@ import {
     streamText,
 } from "ai"
 import { z } from "zod"
-import { getAIModel, supportsPromptCaching } from "@/lib/ai-providers"
+import {
+    getAIModel,
+    getCacheBreakpointProviderOptions,
+    supportsPromptCaching,
+} from "@/lib/ai-providers"
 import { findCachedResponse } from "@/lib/cached-responses"
 import {
     getTelemetryConfig,
@@ -230,13 +234,16 @@ async function handleChatRequest(req: Request): Promise<Response> {
     }
 
     // Get AI model with optional client overrides
-    const { model, providerOptions, headers, modelId } =
+    const { model, providerOptions, headers, modelId, provider } =
         getAIModel(clientOverrides)
 
-    // Check if model supports prompt caching
-    const shouldCache = supportsPromptCaching(modelId)
+    // Check if model supports prompt caching for the resolved provider
+    const shouldCache = supportsPromptCaching(modelId, provider)
+    // The cache marker shape differs per provider's AI SDK adapter
+    const cacheBreakpointProviderOptions =
+        getCacheBreakpointProviderOptions(provider)
     console.log(
-        `[Prompt Caching] ${shouldCache ? "ENABLED" : "DISABLED"} for model: ${modelId}`,
+        `[Prompt Caching] ${shouldCache ? "ENABLED" : "DISABLED"} for model: ${modelId} (provider: ${provider})`,
     )
 
     // Get the appropriate system prompt based on model (extended for Opus/Haiku 4.5)
@@ -313,9 +320,7 @@ ${lastMessageText}
             if (enhancedMessages[i].role === "assistant") {
                 enhancedMessages[i] = {
                     ...enhancedMessages[i],
-                    providerOptions: {
-                        bedrock: { cachePoint: { type: "default" } },
-                    },
+                    providerOptions: cacheBreakpointProviderOptions,
                 }
                 break // Only cache the last assistant message
             }
@@ -333,9 +338,7 @@ ${lastMessageText}
             role: "system" as const,
             content: systemMessage,
             ...(shouldCache && {
-                providerOptions: {
-                    bedrock: { cachePoint: { type: "default" } },
-                },
+                providerOptions: cacheBreakpointProviderOptions,
             }),
         },
         // Cache breakpoint 2: Previous and Current diagram XML context
@@ -343,9 +346,7 @@ ${lastMessageText}
             role: "system" as const,
             content: `${previousXml ? `Previous diagram XML (before user's last message):\n"""xml\n${previousXml}\n"""\n\n` : ""}Current diagram XML (AUTHORITATIVE - the source of truth):\n"""xml\n${xml || ""}\n"""\n\nIMPORTANT: The "Current diagram XML" is the SINGLE SOURCE OF TRUTH for what's on the canvas right now. The user can manually add, delete, or modify shapes directly in draw.io. Always count and describe elements based on the CURRENT XML, not on what you previously generated. If both previous and current XML are shown, compare them to understand what the user changed. When using edit_diagram, COPY search patterns exactly from the CURRENT XML - attribute order matters!`,
             ...(shouldCache && {
-                providerOptions: {
-                    bedrock: { cachePoint: { type: "default" } },
-                },
+                providerOptions: cacheBreakpointProviderOptions,
             }),
         },
     ]

--- a/frontend/lib/ai-providers.ts
+++ b/frontend/lib/ai-providers.ts
@@ -24,6 +24,7 @@ interface ModelConfig {
     providerOptions?: any
     headers?: Record<string, string>
     modelId: string
+    provider: ProviderName
 }
 
 export interface ClientOverrides {
@@ -673,19 +674,58 @@ export function getAIModel(overrides?: ClientOverrides): ModelConfig {
         providerOptions = customProviderOptions
     }
 
-    return { model, providerOptions, headers, modelId }
+    return { model, providerOptions, headers, modelId, provider }
 }
 
+// Providers whose AI SDK adapters understand Claude prompt-caching markers.
+const PROMPT_CACHING_PROVIDERS: ProviderName[] = [
+    "bedrock",
+    "anthropic",
+    "openrouter",
+]
+
 /**
- * Check if a model supports prompt caching.
- * Currently only Claude models on Bedrock support prompt caching.
+ * Check if prompt caching can be applied for the given model and provider.
+ *
+ * Prompt caching requires both a Claude model and a provider whose AI SDK
+ * adapter understands a Claude cache marker. When the provider is omitted the
+ * check falls back to the model name only (backwards compatible).
  */
-export function supportsPromptCaching(modelId: string): boolean {
-    // Bedrock prompt caching is supported for Claude models
-    return (
+export function supportsPromptCaching(
+    modelId: string,
+    provider?: ProviderName,
+): boolean {
+    const isClaudeModel =
         modelId.includes("claude") ||
         modelId.includes("anthropic") ||
         modelId.startsWith("us.anthropic") ||
         modelId.startsWith("eu.anthropic")
-    )
+
+    if (!isClaudeModel) {
+        return false
+    }
+
+    // Without a provider we can only gate on the model name (legacy behaviour).
+    if (!provider) {
+        return true
+    }
+
+    return PROMPT_CACHING_PROVIDERS.includes(provider)
+}
+
+/**
+ * Build the provider-specific marker that flags a message for prompt caching.
+ *
+ * Each AI SDK adapter expects the cache marker under its own namespace:
+ * Bedrock uses `cachePoint`, while the Anthropic adapter (also used for
+ * OpenRouter Claude models) expects `cacheControl`.
+ */
+export function getCacheBreakpointProviderOptions(
+    provider: ProviderName,
+): Record<string, unknown> {
+    if (provider === "bedrock") {
+        return { bedrock: { cachePoint: { type: "default" } } }
+    }
+
+    return { anthropic: { cacheControl: { type: "ephemeral" } } }
 }


### PR DESCRIPTION
## What

Make prompt caching provider-aware so it actually works for the documented `anthropic` and `openrouter` configurations, not just Bedrock.

## Why

Prompt caching is currently wired up for Bedrock only, even though the README documents `AI_PROVIDER=anthropic` and `AI_PROVIDER=openrouter` as supported setups. Two issues combine so that caching silently no-ops outside Bedrock:

1. **`frontend/app/api/chat/route.ts` (cache breakpoints, previously ~L317/L337/L347)** — the cache markers were hardcoded to the Bedrock namespace `providerOptions.bedrock.cachePoint`, and applied whenever `supportsPromptCaching(modelId)` returned true. With `@ai-sdk/anthropic`, the adapter expects `providerOptions.anthropic.cacheControl = { type: "ephemeral" }`; the `bedrock` namespace is just ignored, so no cache breakpoints are ever sent and nothing gets cached.

2. **`frontend/lib/ai-providers.ts` (`supportsPromptCaching`, previously ~L683)** — gating was on the model-name substring only (`claude`/`anthropic`), with no provider dimension. So a Claude model on a provider that can't honor a Bedrock cache marker still reported caching as enabled.

## Fix

- `supportsPromptCaching(modelId, provider?)` now takes the resolved provider and only enables caching for providers whose AI SDK adapter understands a Claude cache marker (`bedrock`, `anthropic`, `openrouter`). The `provider` argument is optional and falls back to the old model-name-only behaviour, so existing callers keep working.
- `getAIModel` now returns the resolved `provider` (it was already computed internally), so `route.ts` can pass it through.
- New `getCacheBreakpointProviderOptions(provider)` emits the correct marker shape per provider:
  - `bedrock` → `{ bedrock: { cachePoint: { type: "default" } } }` (unchanged)
  - `anthropic` / `openrouter` (and other Claude-capable adapters) → `{ anthropic: { cacheControl: { type: "ephemeral" } } }`
- `route.ts` uses that helper for all three cache breakpoints (last assistant message + the two system breakpoints) instead of the hardcoded Bedrock object.

The OpenRouter adapter reads `anthropic.cacheControl` from `providerOptions` and maps it to its own `cache_control` field, so the Anthropic marker shape covers both `anthropic` and `openrouter`.

## Testing

The repo has no test runner (Biome only). `npx biome ci` on the two changed files is clean. Note: `npm run check` reports pre-existing errors/warnings across other files that are already present on `main` (identical counts before and after this change); this PR introduces none.

## Related

Open PR #20 ("custom provider protocol support") touches the Python `autofigure/*` code and some autofigure frontend components, but not `app/api/chat/route.ts` or `lib/ai-providers.ts`, so there's no overlap with this fix.
