### PR TITLE
feat: add Requesty as an OpenAI-compatible provider

### DIFF
--- a/autofigure/README.md
+++ b/autofigure/README.md
@@ -7,7 +7,7 @@ AI-powered Scientific Figure Generation - Generate professional scientific figur
 - **Simple API**: Generate figures from text descriptions or papers
 - **Multiple Formats**: Output SVG and mxGraph XML (draw.io compatible)
 - **Image Enhancement**: Optional AI-powered image beautification with multiple variants
-- **Multiple Providers**: Support for OpenRouter, Bianxie, Gemini
+- **Multiple Providers**: Support for OpenRouter, Requesty, Bianxie, Gemini
 - **Content Types**: Optimized for papers, surveys, blogs, and textbooks
 
 ## Installation
@@ -171,9 +171,11 @@ result = agent.generate_from_file(
 | `generation_api_key` | API key for figure generation | Required |
 | `generation_base_url` | Base URL for API | Provider default |
 | `generation_model` | Model name | Provider default |
-| `generation_provider` | Provider: 'openrouter', 'bianxie', 'gemini' | 'openrouter' |
+| `generation_provider` | Provider: 'openrouter', 'requesty', 'bianxie', 'gemini' | 'openrouter' |
 
 Bianxie users can register at [bianxieai](https://bianxieai.com/autofigure). The Bianxie API uses the default base URL `https://api.bianxie.ai/v1`.
+
+Requesty is an OpenAI-compatible LLM gateway; with `generation_provider="requesty"` the default base URL is `https://router.requesty.ai/v1`.
 
 ### Methodology Extraction Settings
 

--- a/autofigure/config.py
+++ b/autofigure/config.py
@@ -37,7 +37,7 @@ class Config:
     generation_api_key: str = ""
     generation_base_url: Optional[str] = None
     generation_model: Optional[str] = None
-    generation_provider: str = "openrouter"  # openrouter, bianxie, gemini
+    generation_provider: str = "openrouter"  # openrouter, requesty, bianxie, gemini
 
     # Methodology extraction LLM settings (defaults to generation settings)
     methodology_api_key: Optional[str] = None
@@ -47,7 +47,7 @@ class Config:
 
     # Image enhancement settings
     enhancement_api_key: Optional[str] = None
-    enhancement_provider: str = "openrouter"  # openrouter, bianxie, gemini
+    enhancement_provider: str = "openrouter"  # openrouter, requesty, bianxie, gemini
     enhancement_model: Optional[str] = None
     enhancement_base_url: Optional[str] = None
     enhancement_input_type: str = "code2prompt"  # none, code, code2prompt
@@ -97,6 +97,7 @@ class Config:
         """Get default base URL for a provider."""
         urls = {
             "openrouter": "https://openrouter.ai/api/v1",
+            "requesty": "https://router.requesty.ai/v1",
             "bianxie": "https://api.bianxie.ai/v1",
             "gemini": "https://generativelanguage.googleapis.com/v1beta/openai/",
         }
@@ -106,6 +107,7 @@ class Config:
         """Get default model for a provider."""
         models = {
             "openrouter": "google/gemini-3.1-pro-preview",
+            "requesty": "openai/gpt-4o-mini",
             "bianxie": "gemini-3.1-pro-preview",
             "gemini": "gemini-3.1-pro-preview",
         }
@@ -115,6 +117,7 @@ class Config:
         """Get default enhancement model for a provider."""
         models = {
             "openrouter": "google/gemini-3.1-flash-image-preview",
+            "requesty": "google/gemini-3.1-flash-image-preview",
             "bianxie": "gemini-3.1-flash-image-preview",
             "gemini": "gemini-3.1-flash-image-preview",
         }
@@ -165,10 +168,10 @@ class Config:
             AUTOFIGURE_API_KEY: Main API key for generation
             AUTOFIGURE_BASE_URL: Base URL for API
             AUTOFIGURE_MODEL: Model name
-            AUTOFIGURE_PROVIDER: Provider name (openrouter, bianxie, gemini)
+            AUTOFIGURE_PROVIDER: Provider name (openrouter, requesty, bianxie, gemini)
             AUTOFIGURE_METHODOLOGY_API_KEY: API key for methodology extraction
             AUTOFIGURE_ENHANCEMENT_API_KEY: API key for image enhancement
-            AUTOFIGURE_ENHANCEMENT_PROVIDER: Enhancement provider (openrouter, bianxie, gemini)
+            AUTOFIGURE_ENHANCEMENT_PROVIDER: Enhancement provider (openrouter, requesty, bianxie, gemini)
             AUTOFIGURE_ENHANCEMENT_MODEL: Enhancement model name
             AUTOFIGURE_ENHANCEMENT_BASE_URL: Enhancement API base URL
             AUTOFIGURE_ENHANCEMENT_INPUT_TYPE: Enhancement input type (none, code, code2prompt)

--- a/autofigure/utils/llm_client.py
+++ b/autofigure/utils/llm_client.py
@@ -18,6 +18,7 @@ class LLMClient:
 
     Supports OpenAI-compatible APIs including:
     - OpenRouter
+    - Requesty
     - Bianxie
     - Google Gemini (via OpenAI-compatible endpoint)
     - Any OpenAI-compatible endpoint
@@ -37,7 +38,7 @@ class LLMClient:
             api_key: API key for the provider
             base_url: Base URL for the API endpoint
             model: Model name to use
-            provider: Provider name (openrouter, bianxie, gemini)
+            provider: Provider name (openrouter, requesty, bianxie, gemini)
         """
         self.api_key = api_key
         self.base_url = base_url


### PR DESCRIPTION
## What

Adds **Requesty** as a named, OpenAI-compatible LLM provider in the AutoFigure SDK, mirroring the existing OpenRouter wiring 1:1.

- `autofigure/config.py`: add a `"requesty"` branch to `_get_default_base_url` (`https://router.requesty.ai/v1`), `_get_default_model` (`openai/gpt-4o-mini`), and `_get_default_enhancement_model`; update the provider comments and `from_env` docstring.
- `autofigure/utils/llm_client.py`: list Requesty among the supported OpenAI-compatible providers. No special-casing is required — Requesty uses the exact same `openai` SDK path as OpenRouter.
- `autofigure/README.md`: add Requesty to the provider feature list and the `generation_provider` options, plus one factual line on the default base URL.

## Why

Requesty is an OpenAI-compatible LLM gateway. Model naming (`provider/model`) and the `Authorization: Bearer` auth header are identical to OpenRouter, so it slots into the existing provider abstraction with no behavioral changes for other providers.

## Tested against the live endpoint

A `POST` to `https://router.requesty.ai/v1/chat/completions` with `model=openai/gpt-4o-mini` returned **HTTP 200** and a valid completion. I also verified that `Config(generation_provider="requesty")` resolves the expected base URL (`https://router.requesty.ai/v1`) and default model (`openai/gpt-4o-mini`).

## Scope / compliance

Code-level provider entry plus a single factual row in the existing provider list — no new dependencies, no changes to other providers' defaults. The frontend Vercel-AI-SDK provider layer is intentionally untouched to keep this change focused on the SDK.

---

I work at Requesty. This mirrors the existing OpenRouter provider as closely as possible. Happy to adjust wording/placement or close it if it's not a fit.
